### PR TITLE
Refactor RefreshButton Event and Enable Switching with Number/Symbol Keys

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -25,7 +25,7 @@
                     <ControlTemplate TargetType="{x:Type ok:vButton}">
                         <Grid>
                             <Rectangle x:Name="BtnBackground" Fill="{TemplateBinding Background}" RadiusX="10" RadiusY="10" />
-                            <TextBlock x:Name="ShiftText" FontSize="19" Foreground="Gray" Margin="0,0,5,3" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShiftText}"/>
+                            <TextBlock x:Name="ShiftText" FontSize="19" Foreground="Gray" Margin="0,0,5,3" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{TemplateBinding ShiftText}"/>
                             <ContentPresenter x:Name="BtnContent" VerticalAlignment="center" HorizontalAlignment="center" Content="{TemplateBinding Content}"/>
                         </Grid>
                     </ControlTemplate>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -15,7 +15,7 @@ using System.Windows.Interop;
 
 namespace OpenKeyboard
 {
-    public delegate void RefreshButton(bool toUpper);
+    public delegate void RefreshButton(bool isShiftPressed, bool isCapsLockOn);
     public partial class MainWindow : Window
     {
         private WindowController mWinController = null;
@@ -95,8 +95,9 @@ namespace OpenKeyboard
 
         public void RefreshButtons()
         {
-            bool toUpper = vKeyboard.isShiftActive || Keyboard.IsKeyToggled(Key.CapsLock);
-            RefreshButton.Invoke(toUpper);
+            bool isCapsLockOn = Keyboard.IsKeyToggled(Key.CapsLock);
+            bool isShiftPressed = vKeyboard.isShiftActive;
+            RefreshButton.Invoke(isShiftPressed, isCapsLockOn);
         }
 
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -91,7 +91,12 @@ namespace OpenKeyboard
                 anchorPoint = currentPoint;
             }
             
-            RefreshButton.Invoke(vKeyboard.isShiftActive || System.Windows.Forms.Control.IsKeyLocked(System.Windows.Forms.Keys.CapsLock));
+        }
+
+        public void RefreshButtons()
+        {
+            bool toUpper = vKeyboard.isShiftActive || Keyboard.IsKeyToggled(Key.CapsLock);
+            RefreshButton.Invoke(toUpper);
         }
 
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)

--- a/vButton.cs
+++ b/vButton.cs
@@ -72,16 +72,18 @@ namespace OpenKeyboard
             return final;
         }//func
 
-        public void RefreshButton(bool toUpper)
+        public void RefreshButton(bool isShiftPressed, bool isCapsLockOn)
         {
 
 
             if (!string.IsNullOrEmpty(ShiftText))
             {
-                Content = toUpper ? shiftTextValue : defaultText;
-                ShiftText = toUpper ? defaultText : shiftTextValue;
+                Content = isShiftPressed ? shiftTextValue : defaultText;
+                ShiftText = isShiftPressed ? defaultText : shiftTextValue;
                 return;
             }
+
+            bool toUpper = isCapsLockOn ^ isShiftPressed;
 
             var txt = Content as string;
 

--- a/vButton.cs
+++ b/vButton.cs
@@ -9,24 +9,41 @@ namespace OpenKeyboard
     {
         public KeyboardCommand KBCommand;
 
+        private string defaultText = "";
+        private string shiftTextValue = "";
+
         // Dependency Property
-        public static DependencyProperty ShiftTextProperty = DependencyProperty.Register("ShiftText", typeof(string), typeof(TextBlock), new FrameworkPropertyMetadata(""));
+        public static readonly DependencyProperty ShiftTextProperty = DependencyProperty.Register("ShiftText", typeof(string), typeof(vButton), new FrameworkPropertyMetadata(""));
         public string ShiftText
         {
             get { return (string)this.GetValue(ShiftTextProperty); }
-            set { this.SetValue(ShiftTextProperty, value); }
+            set
+            {
+                this.SetValue(ShiftTextProperty, value);
+                if (string.IsNullOrEmpty(shiftTextValue))
+                {
+                    shiftTextValue = value;
+                }
+            }
         }//prop
 
         public string Title
         {
             set
             {
-                if (value.StartsWith("\\u")) parseUnicode(value);
-                else Content = value;
+                if (value.StartsWith("\\u"))
+                {
+                    defaultText = parseUnicode(value);
+                }
+                else
+                {
+                    defaultText = value;
+                    Content = value;
+                }
             }
         }//prop
 
-        private void parseUnicode(string txt)
+        private string parseUnicode(string txt)
         {
             int pos = 0;
             string tmp = "", final = "";
@@ -35,7 +52,7 @@ namespace OpenKeyboard
             if (txt.Length == 6)
             {
                 Content = (char)Int32.Parse(txt.Substring(2), System.Globalization.NumberStyles.HexNumber);
-                return;
+                return Content.ToString();
             }//if
 
             //More then one possible unicode characters
@@ -52,14 +69,26 @@ namespace OpenKeyboard
             }//while
 
             Content = final;
+            return final;
         }//func
 
         public void RefreshButton(bool toUpper)
         {
+
+
+            if (!string.IsNullOrEmpty(ShiftText))
+            {
+                Content = toUpper ? shiftTextValue : defaultText;
+                ShiftText = toUpper ? defaultText : shiftTextValue;
+                return;
+            }
+
             var txt = Content as string;
 
-            if (txt.Length == 1)
+            if (txt.Length == 1 && char.IsLetter(txt[0]))
                 Content = toUpper ? txt.ToUpper() : txt.ToLower();
+
+
         }
     }//cls
 }//ns

--- a/vLayout.cs
+++ b/vLayout.cs
@@ -134,7 +134,7 @@ namespace OpenKeyboard
 
                         rGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(gLen, GridUnitType.Star) });
 
-                        var button = CreateButton(key, iKey);
+                        var button = CreateButton(key, iKey, uiWindow);
 
                         ((MainWindow)uiWindow).RefreshButton += button.RefreshButton;
 
@@ -161,7 +161,7 @@ namespace OpenKeyboard
             return grid;
         }//func
 
-        private static vButton CreateButton(XmlElement elm, int col)
+        private static vButton CreateButton(XmlElement elm, int col, Window uiWindow)
         {
             string code, shCode, shText
                 , title = elm.GetAttribute("text")
@@ -194,6 +194,10 @@ namespace OpenKeyboard
                     btn.KBCommand.shSendString = elm.GetAttribute("shstring");
 
                     btn.PreviewMouseLeftButtonDown += BtnTouch_Down;
+                    btn.PreviewMouseLeftButtonDown += (sender, e) =>
+                    {
+                        ((MainWindow)uiWindow).RefreshButtons();
+                    };
                     btn.PreviewMouseLeftButtonUp += BtnTouch_Up;
 
                     break;


### PR DESCRIPTION
### Overview
This pull request refactors the `RefreshButton` event handler and enables switching with number and symbol keys.

### Changes
1. Moved the `RefreshButton` event handler from `MouseMove` to `MouseDown` for better user interaction.
2. Enabled the switching between number and symbol keys.